### PR TITLE
ESNI transformation

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -608,15 +608,15 @@ ESNI transformation as the handshake transcript, and the other using the
 ClientHello post ESNI transformation. One of these two traffic secrets is
 promoted to the handshake traffic secret using the following procedure.
 
-If the encrypted record can be sucessfully decrypted using the former traffic
-secret, it means that the server has received and recognized the protected
-server name. Then, that traffic secret is promoted to the handshake traffic
-secret, and the handshake continues accordingly.
+If the encrypted record can be sucessfully decrypted using the
+pre-transformation traffic secret, it means that the server has received and
+recognized the protected server name. Then, that traffic secret is promoted to
+the handshake traffic secret, and the handshake continues accordingly.
 
-Otherwise, the latter traffic secret is promoted to the handshake traffic
-secret, as the server was unable to unwind the ESNI transformation.  The client
-then proceeds with the handshake, authenticating for ESNIKeys.public_name as
-described in {{auth-public-name}}.
+Otherwise, the post-transformation traffic secret is promoted to the handshake
+traffic secret, as the server was unable to unwind the ESNI transformation. The
+client then proceeds with the handshake, authenticating for ESNIKeys.public_name
+as described in {{auth-public-name}}.
 
 After the handshake successfully concludes with the public name authenticated,
 the client MUST check if it has received an "encrypted_server_name" extension as

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -115,21 +115,25 @@ comes from {{RFC8446}}; Section 3.
 This document is designed to operate in the topology shown below.
 
 ~~~~
-                +--------------------+       +---------------------+
-                |                    |       |                     |
-                |   2001:DB8::1111   |       |   2001:DB8::EEEE    |
-Client <------------------------------------>|                     |
-                | public.example.com |       | private.example.com |
-                |                    |       |                     |
-                +--------------------+       +---------------------+
-                 Client-Facing Server             Backend Server
+                          +-----------------+    +------------------+
+                          |                 |    |                  |
+                          | pub.example.com |    | priv.example.com |
+                          | (2001:DB8::111) |    | (2001:DB8::EEEE) |
+                          |                 |    |                  |
+       <---  TLS 1.3  -------------------------->|                  |
+Client                    |                 |    |                  |
+       <-  ESNI Trans-  ->|                 |    |                  |
+            formation     |                 |    |                  |
+                          +-----------------+    +------------------+
+                         Client-Facing Server       Backend Server
 ~~~~
 {: #topology title="Topology"}
 
-The client-facing server acts as a proxy between the client and the backend
-server. It unprotects the partially-encrypted ClientHello sent by the client
-(see {{esni-transformation}}), and forwards the restored ClientHello as well as
-the following TLS records to the backend server, which is identified during the
+Client sends a transformed ClientHello on the wire, that contains an encrypted
+server name (see {{esni-transformation}}). The client-facing server acts as a
+proxy between the client and the backend server, decrypting the server name sent
+by the client, and forwards the restored ClientHello as well as the the
+following TLS records to the backend server, which is identified during the
 inverse transformation. The client-facing server is also responsible for
 providing the up-to-date ESNI keys should there be a mismatch (see
 {{server-behavior}}).

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -130,8 +130,8 @@ The client-facing server acts as a proxy between the client and the backend
 server. It unprotects the partially-encrypted ClientHello sent by the client
 (see {{esni-transformation}}), and forwards the reconstructed ClientHello as
 well as the following TLS records to the backend server, which is identified
-during the unprotection transformation. The client-facing server is also
-responsible for providing the up-to-date ESNI keys should there be a mismatch
+during the inverse transformation. The client-facing server is also responsible
+for providing the up-to-date ESNI keys should there be a mismatch
 (see {{server-behavior}}).
 
 The backend server can be a stock TLS 1.3 server.
@@ -776,11 +776,11 @@ the "server_name" extension. Any actual "server_name" extension is
 ignored, which also means the server MUST NOT send the "server_name"
 extension to the client.
 
-Upon determining the true SNI, the client-facing server reverses the
+Upon determining the true SNI, the client-facing server inverts the
 transformation of the ClientHello as defined in {{esni-transformation}}, then
-forwards that recovered message to the backend server.  The reverse
-transformation MUST also be applied to the ClientHello sent in response to a
-HelloRetryRequest.
+forwards the restored message to the backend server.  The inverse transformation
+MUST also be applied to the ClientHello that the client sends in in response to
+a HelloRetryRequest.
 
 ## Backend Server Behavior {#backend-server-behavior}
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -493,7 +493,7 @@ The client then builds the first ClientHello, that has the following properties:
   "encrypted_server_name" extension carrying the ClientEncryptedSNI structure of
   type `esni_parameters`.
 
-The client MUST NOT send a "cached_info" extension {{!RFC7924}} with a
+The client MUST NOT include a "cached_info" extension {{!RFC7924}} with a
 CachedObject entry whose CachedInformationType is "cert".
 
 A ClientHello generated in response to a HelloRetryRequest MUST contain a

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -128,11 +128,11 @@ Client <------------------------------------>|                     |
 
 The client-facing server acts as a proxy between the client and the backend
 server. It unprotects the partially-encrypted ClientHello sent by the client
-(see {{esni-transformation}}), and forwards the reconstructed ClientHello as
-well as the following TLS records to the backend server, which is identified
-during the inverse transformation. The client-facing server is also responsible
-for providing the up-to-date ESNI keys should there be a mismatch
-(see {{server-behavior}}).
+(see {{esni-transformation}}), and forwards the restored ClientHello as well as
+the following TLS records to the backend server, which is identified during the
+inverse transformation. The client-facing server is also responsible for
+providing the up-to-date ESNI keys should there be a mismatch (see
+{{server-behavior}}).
 
 The backend server can be a stock TLS 1.3 server.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -794,9 +794,11 @@ The backend server SHOULD pad the Certificate message, via padding at the record
 layer, such that its length equals the size of the largest possible Certificate
 message covered by the same ESNI keys.
 
-The backend server SHOULD ignore the "encrypted_server_name" extension of type
+The backend server ignores the "encrypted_server_name" extension of type
 `esni_parameters`, as the purpose of this parameters is to derive the handshake
-traffic secret from a handshake transcript invisible to an observer.
+traffic secret from a handshake transcript invisible to an observer. Future
+extensions might use the values in particular ways, for example to authenticate
+the ServerHello.
 
 # Compatibility Issues
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -129,10 +129,10 @@ Client                    |                 |    |                  |
 ~~~~
 {: #topology title="Topology"}
 
-Client sends a transformed ClientHello on the wire, that contains an encrypted
-server name (see {{esni-transformation}}). The client-facing server acts as a
-proxy between the client and the backend server, decrypting the server name sent
-by the client, and forwards the restored ClientHello as well as the the
+The client sends a transformed ClientHello on the wire, that contains an
+encrypted server name (see {{esni-transformation}}). The client-facing server
+acts as a proxy between the client and the backend server, decrypting the server
+name sent by the client, and forwards the restored ClientHello as well as the
 following TLS records to the backend server, which is identified during the
 inverse transformation. The client-facing server is also responsible for
 providing the up-to-date ESNI keys should there be a mismatch (see

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -141,7 +141,7 @@ providing the up-to-date ESNI keys should there be a mismatch (see
 
 The backend server can be a stock TLS 1.3 server.
 
-The client-facing server and the backend server can be collocated. When they are
+The client-facing server and the backend server can be colocated. When they are
 not, the communication between these two servers MUST be encrypted (e.g., by
 using VPN) so that it would be unobservable by a third party.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -117,7 +117,8 @@ This document is designed to operate in the topology shown below.
 ~~~~
 +----+                   +------------------+    +------------------+
 |    |                   |                  |    |                  |
-|    |                   | pub.example.com  |    | priv.example.com |
+|    |                   |  client-facing.  |    |     backend.     |
+|    |                   |   example.com    |    |   example.com    |
 |    |                   | (2001:DB8::1111) |    | (2001:DB8::EEEE) |
 |    |                   |                  |    |                  |
 |    |<---  TLS 1.3  --------------------------->|                  |

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -583,7 +583,7 @@ TLS 1.3 AEAD:
 
 where ClientHelloPlaintext is the entire ClientHello to be transformed but the
 "server_name" extension being skipped.  Feeding the unencrypted part of the
-ClientHello in the AAD of AEAD-Encrypt binds the encrypted value to the prevents
+ClientHello in the AAD of AEAD-Encrypt binds the encrypted value and prevents
 cut-and-paste attacks.
 
 Note: future extensions may end up reusing the server's ESNIKeyShareEntry

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -115,17 +115,17 @@ comes from {{RFC8446}}; Section 3.
 This document is designed to operate in the topology shown below.
 
 ~~~~
-                          +-----------------+    +------------------+
-                          |                 |    |                  |
-                          | pub.example.com |    | priv.example.com |
-                          | (2001:DB8::111) |    | (2001:DB8::EEEE) |
-                          |                 |    |                  |
-       <---  TLS 1.3  -------------------------->|                  |
-Client                    |                 |    |                  |
-       <-  ESNI Trans-  ->|                 |    |                  |
-            formation     |                 |    |                  |
-                          +-----------------+    +------------------+
-                         Client-Facing Server       Backend Server
++----+                   +------------------+    +------------------+
+|    |                   |                  |    |                  |
+|    |                   | pub.example.com  |    | priv.example.com |
+|    |                   | (2001:DB8::1111) |    | (2001:DB8::EEEE) |
+|    |                   |                  |    |                  |
+|    |<---  TLS 1.3  --------------------------->|                  |
+|    |                   |                  |    |                  |
+|    |<-  ESNI Trans-  ->|                  |    |                  |
+|    |     formation     |                  |    |                  |
++----+                   +------------------+    +------------------+
+Client                   Client-Facing Server       Backend Server
 ~~~~
 {: #topology title="Topology"}
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -479,7 +479,7 @@ to client and server session states.
 In order to send an encrypted SNI, the client MUST first select one of
 the server ESNIKeyShareEntry values and generate an (EC)DHE share in the
 matching group. This share will then be sent to the server in the
-"encrypted_sni" extension and used to derive the SNI encryption key. It does not affect the
+"encrypted_server_name" extension and used to derive the SNI encryption key. It does not affect the
 (EC)DHE shared secret used in the TLS key schedule. It MUST also select
 an appropriate cipher suite from the list of suites offered by the
 server. If the client is unable to select an appropriate group or suite it

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -480,7 +480,7 @@ In order to send an encrypted SNI, the client MUST first select one of
 the server ESNIKeyShareEntry values and generate an (EC)DHE share in the
 matching group. This share will then be sent to the server in the
 "encrypted_server_name" extension and used to derive the SNI encryption key. It does not affect the
-(EC)DHE shared secret used in the TLS key schedule. It MUST also select
+(EC)DHE shared secret used in the TLS key schedule. The client MUST also select
 an appropriate cipher suite from the list of suites offered by the
 server. If the client is unable to select an appropriate group or suite it
 SHOULD ignore that ESNIKeys value and MAY attempt to use another value provided

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -585,7 +585,8 @@ This value is placed in an "encrypted_server_name" extension.
 The client MUST place the value of ESNIKeys.public_name in the "server_name"
 extension. (This is required for technical conformance with {{!RFC7540}};
 Section 9.2.) The client MUST NOT send a "cached_info" extension {{!RFC7924}}
-with a CachedObject entry whose CachedInformationType is "cert".
+with a CachedObject entry whose CachedInformationType is "cert", since this
+indication would divulge the true value of the SNI.
 
 ### Handling the server response {#handle-server-response}
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -586,7 +586,7 @@ The client MUST place the value of ESNIKeys.public_name in the "server_name"
 extension. (This is required for technical conformance with {{!RFC7540}};
 Section 9.2.) The client MUST NOT send a "cached_info" extension {{!RFC7924}}
 with a CachedObject entry whose CachedInformationType is "cert", since this
-indication would divulge the true value of the SNI.
+indication would divulge the true server name.
 
 ### Handling the server response {#handle-server-response}
 


### PR DESCRIPTION
An attempt to separate the ESNI exchange to a sub-protocol between the client and the client-facing server.

Major changes:
* No more modes. The "Shared Mode" is gone. We simply state that the client-facing and the backend server can be collocated.
* Trial decryption is used to determine if the server recognized the encrypted server name.
* Allows the use of stock TLS 1.3 server as the backend server (even the true SNI is forwarded to the backend).
* Entire CH is authenticated.
* No more retransmission of the ESNI extension in the 2nd CH (sent in response to HRR).
* The only use of the server-sent ESNI extension becomes the correction of the ESNI keys.
* Removed the definition of "(non-)ESNI PSK." Instead, the client-facing server is forbidden to resume when it sees an out-of-sync ESNI keys being used.

The only quirks are that the client is required to do trial decryption, and that the backend server is required to pad the Certificate message. We might want to address these two issues at once, by allowing the client-facing server to pad the first few encrypted TLS records, using a bit pattern that indicates that the fronting server has successfully decrypted the ESNI extension.